### PR TITLE
MSMB Update

### DIFF
--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -137,7 +137,7 @@ def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
                 label = clusterer.labels_[i][j]
                 center = msm.mapping_[label]
                 dist = np.linalg.norm(clustering[i][j] - centers[label])
-                if center != -1 and dist < dists[label]:
+                if center != -1 and dist < dists[center]:
                     dists[center] = dist
                     centermap[center] = (i, j)
             except KeyError:

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -5,11 +5,15 @@ Extract AWE inputs from an existing MSM and corresponding clustering.
 Author: Jeff Kinnison <jkinniso@nd.edu>
 """
 
+# Python Standard Library imports
 import argparse
 import copy
 import glob
 import os
 import os.path
+import subprocess
+
+# Third-Party imports
 import mdtraj
 from msmbuilder.dataset import dataset
 from msmbuilder.utils import load, draw_samples
@@ -19,96 +23,294 @@ import numpy as np
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-n', '--n-samples',
-                        required=True,
-                        type=int,
-                        help='the number of samples to draw from each MSM state'
-                        )
+    # General Options
+    general = parser.add_group('General Arguments')
 
-    parser.add_argument('-m', '--msm',
-                        default='msm.pkl',
+    general.add_argument('-i', '--input-trajectories',
+                        default='trajectories/*',
                         type=str,
-                        help='path to the serialized MSMBuilder msm object'
+                        help='path or glob to the input trajectories'
                         )
 
-    parser.add_argument('-c', '--clustering',
-                        default='clustering/',
-                        type=str,
-                        help='path to the clustered data'
-                        )
-
-    parser.add_argument('-C', '--clusterer',
-                        default='clusterer.pkl',
-                        type=str,
-                        help='path to serialized clusterer fit to clustering'
-                        )
-
-    parser.add_argument('-i', '--input-trajectories',
-                        default='trajectories',
-                        type=str,
-                        help='path to the input trajectories'
-                        )
-
-    parser.add_argument('-t', '--topology',
+    general.add_argument('-t', '--topology',
                         default='input.pdb',
                         type=str,
                         help='path to the trajectory topology file'
                         )
 
-    parser.add_argument('-r', '--reference',
+    general.add_argument('-r', '--reference',
                         default='folded.pdb',
                         type=str,
                         help='path to the reference trajectory'
                         )
 
-    parser.add_argument('-a', '--atom-selection',
-                        default='backbone',
+    # Featurization Options
+
+    featurize = parser.add_group("Featurization Arguments")
+
+    featurize.add_argument('-f', '--featurizer',
+                           default='DihedralFeaturizer',
+                           type=str,
+                           help='MSMBuilder featurizer class to use'
+                           choices=['ContactFeaturizer',
+                                    'DRIDFeaturizer',
+                                    'DihedralFeaturizer',
+                                    'RMSDFeaturizer',
+                                    'RawPositionsFeaturizer']
+                           )
+
+    featurize.add_argument('--featurizer-out',
+                           default='feat.pkl',
+                           type=str,
+                           help='path to the file that will store the serialized featurizer',
+                           )
+
+    featurize.add_argument('--featurized-data',
+                           default='feats.h5',
+                           type=str,
+                           help='path to the file that will store the featurized data'
+                           )
+
+    featurize.add_argument('--featurizer-args',
+                           default='',
+                           type=str,
+                           help='a comma-delimited list of additional arguments to the featurizer (e.g. --arg1,val1,--arg2,val2)'
+                           )
+
+    # Decomposition Options
+
+    decomp = parser.add_group('Decomposition Options')
+
+    decomp.add_argument('-d', '--decomposer',
+                        default='tICA',
                         type=str,
-                        help='MDTraj/VMD atom selection string'
+                        help='MSMBuilder decomposition class to use',
+                        choices=['PCA',
+                                 'SparseTICA',
+                                 'tICA']
                         )
 
-    parser.add_argument('--samples-out',
-                        default='samples',
+    decomp.add_argument('--decomp-out',
+                        default='tica.pkl',
                         type=str,
-                        help='path to the cell sampling output directory'
+                        help='path to the file that will store the serialized decomposer',
                         )
 
-    parser.add_argument('--centers-out',
-                        default='centers',
+    decomp.add_argument('--decomp-data',
+                        default='ticas.h5',
                         type=str,
-                        help='path to the cell centers output directory'
+                        help='path to the file that will store the decomposed data'
                         )
 
-    parser.add_argument('--folded-assignments',
-                        default=['folded.dat', 'unfolded.dat']
-                        nargs=2,
+    decomp.add_argument('--n-components',
+                        default=5,
+                        type=int,
+                        help='the number of components to find in the decomposition')
+
+    decomp.add_argument('--decomp-args',
+                        default='',
                         type=str,
-                        help='paths to the cell assignment output files'
+                        help='a comma-delimited list of additional arguments to the decomposer (e.g. --arg1,val1,--arg2,val2)'
                         )
 
-    parser.add_argument('--folded-threshold',
-                        default=3.0,
-                        type=float,
-                        help='RMSD to folded state threshold (AA)'
+    # Clustering Options
+
+    cluster = parser.add_group('Clustering Options')
+
+    cluster.add_argument('-c', '--clusterer',
+                        default='MiniBatchKMeans',
+                        type=str,
+                        help='MSMBuilder clusterer class to use',
+                        choices=['AffinityPropagation',
+                                 'GMM',
+                                 'KCenters',
+                                 'KMeans',
+                                 'KMedoids',
+                                 'LandmarkAgglomerative',
+                                 'MeanShift',
+                                 'MiniBatchKMeans',
+                                 'MiniBatchKMedoids',
+                                 'RegularSpatial',
+                                 'SpectralClustering',
+                                 'Ward']
                         )
 
-    parser.add_argument('--cells-datafile',
-                        default='cells.dat',
-                        type=str,
-                        help='the cell data output file'
-                        )
+    cluster.add_argument('--clusterer-out',
+                         default='cluster.pkl',
+                         type=str,
+                         help='path to the file that will store the serialized clusterer',
+                         )
 
-    parser.add_argument('--weights-datafile',
-                        default='weights.dat',
-                        type=str,
-                        help='the cell weights data output file',
-                        )
+    cluster.add_argument('--clustered-data',
+                         default='labeled-trajs.h5',
+                         type=str,
+                         help='path to the file that will store the clustered data'
+                         )
+
+    cluster.add_argument('--n-clusters',
+                         default=100,
+                         type=int,
+                         help='the target number of clusters to find'
+                         )
+
+    cluster.add_argument('--clusterer-args',
+                         default='',
+                         type=str,
+                         help='a comma-delimited list of additional arguments to the clusterer (e.g. --arg1,val1,--arg2,val2)'
+                         )
+
+    # MSM Options
+
+    msm = parser.add_group('MSM Options')
+
+    msm.add_argument('-m', '--msm',
+                     default='tICA',
+                     type=str,
+                     help='MSMBuilder msmer class to use',
+                     choices=['BayesianMSM', 'MSM']
+                     )
+
+    msm.add_argument('--msm-out',
+                     default='msm.pkl',
+                     type=str,
+                     help='path to the file that will store the serialized msmer',
+                     )
+
+    msm.add_argument('--lag-time',
+                     default=1,
+                     type=int,
+                     help='lag time for determinig MSM populations')
+
+    msm.add_argument('--msm-args',
+                     default='',
+                     type=str,
+                     help='a comma-delimited list of additional arguments to the msmer (e.g. --arg1,val1,--arg2,val2)'
+                     )
+
+    # Sampling Options
+
+    sampling = parser.add_group('Sampling Options')
+
+    sampling.add_argument('-n', '--n-samples',
+                          required=True,
+                          type=int,
+                          help='the number of samples to draw from each MSM state'
+                          )
+
+    sampling.add_argument('-a', '--atom-selection',
+                          default='backbone',
+                          type=str,
+                          help='MDTraj/VMD atom selection string'
+                          )
+
+    sampling.add_argument('--samples-out',
+                          default='samples',
+                          type=str,
+                          help='path to the cell sampling output directory'
+                          )
+
+    sampling.add_argument('--centers-out',
+                          default='centers',
+                          type=str,
+                          help='path to the cell centers output directory'
+                          )
+
+    sampling.add_argument('--folded-assignments',
+                          default=['folded.dat', 'unfolded.dat']
+                          nargs=2,
+                          type=str,
+                          help='paths to the cell assignment output files'
+                          )
+
+    sampling.add_argument('--folded-threshold',
+                          default=3.0,
+                          type=float,
+                          help='RMSD to folded state threshold (AA)'
+                          )
+
+    sampling.add_argument('--cells-datafile',
+                          default='cells.dat',
+                          type=str,
+                          help='the cell data output file'
+                          )
+
+    sampling.add_argument('--weights-datafile',
+                          default='weights.dat',
+                          type=str,
+                          help='the cell weights data output file',
+                          )
 
     return parser.parse_args(args)
 
 
+def featurize(args):
+    """
+
+    """
+    cmd = ['msmb', args.featurizer,
+           '--out', args.featurizer_out,
+           '--transformed', args.featurized_data,
+           '--top', args.topology,
+           '--trjs', args.input_trajectories].extend(args.featurizer_args.split(','))
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: Featurization failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
+def decompose(args):
+    """
+
+    """
+    cmd = ['msmb', args.decomposer,
+           '-i', args.featurized_data,
+           '--out', args.decomposer_out,
+           '--transformed', args.decomposed_data,
+           '--n_components', str(args.n_components)].extend(args.decomposer_args.split(','))
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: Decomposition failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
+def cluster(args):
+    """
+
+    """
+    cmd = ['msmb', args.clusterer,
+           '-i', args.decomposed_data,
+           '--out', args.clusterer_out,
+           '--transformed', args.clustered_data,
+           '--n_clusters', str(args.n_clusters)].extend(args.clusterer_args.split(','))
+    try:
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: Clustering failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
+def build_msm():
+    """
+
+    """
+    cmd = ['msmb', args.msm,
+           '-i', args.clustered_data,
+           '--out', args.msm_out,
+           '--lag_time', str(args.lag_time)].extend(args.decomposer_args.split(','))
+    try:
+        subprocess.run('msmb MarkovStateModel -i labeled-trajs.h5 --out msm.pkl --lag_time 1',
+                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+    except subprocess.CalledProcessError as e:
+        print("Error: MSM Building failed")
+        print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
+
+
 def save_samples(msm, clustering, xyz, n_samples, samples_dir):
     """
+    Extract samples from each state in the MSM and save each as an individual PDB.
+
 
     """
     samples = msm.draw_samples(clustering, n_samples)
@@ -184,9 +386,9 @@ def save_cell_assignments(centers_dir, reference, threshold, atom_selection,
                                  str(atom[1]), '\n',
                                  str(atom[2]), '\n']))
 
-        folded.close()
-        unfolded.close()
-        cells.close()
+    folded.close()
+    unfolded.close()
+    cells.close()
 
 
 def save_weights(msm, weights_out):
@@ -199,8 +401,13 @@ def save_weights(msm, weights_out):
 if __name__ == "__main__":
     args = parse_args(None)
 
+    featurize(args)
+    decompose(args)
+    cluster(args)
+    build_msm(args)
+
     msm = load(args.msm)
-    clustering = dataset(args.clustering)
+    clustering = dataset(args.clustered_data)
     clusterer = load(args.clusterer)
     xyz = dataset(args.input_trajectories, args.topology)
 

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -389,8 +389,8 @@ def save_state_centers(msm, clustering, clusterer, decomp, xyz, centers_dir):
     """
 
     """
-    dists = {}
-    centermap = {}
+    dists = {val: float('inf') for key, val in msm.mapping_.items}
+    centermap = {val: (-1, -1) for key, val in msm.mapping_.items}
 
     if not os.path.isdir(centers_dir):
         os.mkdir(centers_dir)

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -434,7 +434,7 @@ def save_cell_assignments(centers_dir, reference, threshold, atom_selection,
                          '\nndims: ', str(3), '\n\n']))
 
     for i in range(0, n_cells):
-        fname = ''.join('Center', str(i), '.pdb')
+        fname = ''.join(['Center', str(i), '.pdb'])
         traj = mdtraj.load(os.path.join(centers_dir, fname))
         rmsd = mdtraj.rmsd(traj, ref,
                            atom_indices=traj.topology.select(atom_selection))

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -389,8 +389,8 @@ def save_state_centers(msm, clustering, clusterer, decomp, xyz, centers_dir):
     """
 
     """
-    dists = {val: float('inf') for key, val in msm.mapping_.items}
-    centermap = {val: (-1, -1) for key, val in msm.mapping_.items}
+    dists = {val: float('inf') for key, val in msm.mapping_.items()}
+    centermap = {val: (-1, -1) for key, val in msm.mapping_.items()}
 
     if not os.path.isdir(centers_dir):
         os.mkdir(centers_dir)

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -24,7 +24,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser()
 
     # General Options
-    general = parser.add_group('General Arguments')
+    general = parser.add_argument_group('General Arguments')
 
     general.add_argument('-i', '--input-trajectories',
                         default='trajectories/*',
@@ -46,12 +46,12 @@ def parse_args(args=None):
 
     # Featurization Options
 
-    featurize = parser.add_group("Featurization Arguments")
+    featurize = parser.add_argument_group("Featurization Arguments")
 
     featurize.add_argument('-f', '--featurizer',
                            default='DihedralFeaturizer',
                            type=str,
-                           help='MSMBuilder featurizer class to use'
+                           help='MSMBuilder featurizer class to use',
                            choices=['ContactFeaturizer',
                                     'DRIDFeaturizer',
                                     'DihedralFeaturizer',
@@ -66,20 +66,20 @@ def parse_args(args=None):
                            )
 
     featurize.add_argument('--featurized-data',
-                           default='feats.h5',
+                           default='feats',
                            type=str,
                            help='path to the file that will store the featurized data'
                            )
 
     featurize.add_argument('--featurizer-args',
-                           default='',
+                           default=None,
                            type=str,
                            help='a comma-delimited list of additional arguments to the featurizer (e.g. --arg1,val1,--arg2,val2)'
                            )
 
     # Decomposition Options
 
-    decomp = parser.add_group('Decomposition Options')
+    decomp = parser.add_argument_group('Decomposition Options')
 
     decomp.add_argument('-d', '--decomposer',
                         default='tICA',
@@ -108,14 +108,14 @@ def parse_args(args=None):
                         help='the number of components to find in the decomposition')
 
     decomp.add_argument('--decomp-args',
-                        default='',
+                        default=None,
                         type=str,
                         help='a comma-delimited list of additional arguments to the decomposer (e.g. --arg1,val1,--arg2,val2)'
                         )
 
     # Clustering Options
 
-    cluster = parser.add_group('Clustering Options')
+    cluster = parser.add_argument_group('Clustering Options')
 
     cluster.add_argument('-c', '--clusterer',
                         default='MiniBatchKMeans',
@@ -154,20 +154,20 @@ def parse_args(args=None):
                          )
 
     cluster.add_argument('--clusterer-args',
-                         default='',
+                         default=None,
                          type=str,
                          help='a comma-delimited list of additional arguments to the clusterer (e.g. --arg1,val1,--arg2,val2)'
                          )
 
     # MSM Options
 
-    msm = parser.add_group('MSM Options')
+    msm = parser.add_argument_group('MSM Options')
 
     msm.add_argument('-m', '--msm',
-                     default='tICA',
+                     default='MarkovStateModel',
                      type=str,
                      help='MSMBuilder msmer class to use',
-                     choices=['BayesianMSM', 'MSM']
+                     choices=['BayesianMSM', 'MarkovStateModel']
                      )
 
     msm.add_argument('--msm-out',
@@ -182,14 +182,14 @@ def parse_args(args=None):
                      help='lag time for determinig MSM populations')
 
     msm.add_argument('--msm-args',
-                     default='',
+                     default=None,
                      type=str,
                      help='a comma-delimited list of additional arguments to the msmer (e.g. --arg1,val1,--arg2,val2)'
                      )
 
     # Sampling Options
 
-    sampling = parser.add_group('Sampling Options')
+    sampling = parser.add_argument_group('Sampling Options')
 
     sampling.add_argument('-n', '--n-samples',
                           required=True,
@@ -216,7 +216,7 @@ def parse_args(args=None):
                           )
 
     sampling.add_argument('--folded-assignments',
-                          default=['folded.dat', 'unfolded.dat']
+                          default=['folded.dat', 'unfolded.dat'],
                           nargs=2,
                           type=str,
                           help='paths to the cell assignment output files'
@@ -251,9 +251,20 @@ def featurize(args):
            '--out', args.featurizer_out,
            '--transformed', args.featurized_data,
            '--top', args.topology,
-           '--trjs', args.input_trajectories].extend(args.featurizer_args.split(','))
+           '--trjs', args.input_trajectories]
+
+    if args.featurizer_args is not None:
+        cmd.extend(args.featurizer_args.split(','))
+
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'featurize.out'), 'w')
+        err = open(os.path.join('logs', 'featurize.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: Featurization failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
@@ -265,11 +276,22 @@ def decompose(args):
     """
     cmd = ['msmb', args.decomposer,
            '-i', args.featurized_data,
-           '--out', args.decomposer_out,
-           '--transformed', args.decomposed_data,
-           '--n_components', str(args.n_components)].extend(args.decomposer_args.split(','))
+           '--out', args.decomp_out,
+           '--transformed', args.decomp_data,
+           '--n_components', str(args.n_components)]
+
+    if args.decomp_args is not None:
+        cmd.extend(args.decomp_args.split(','))
+
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'decomp.out'), 'w')
+        err = open(os.path.join('logs', 'decomp.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: Decomposition failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
@@ -280,65 +302,105 @@ def cluster(args):
 
     """
     cmd = ['msmb', args.clusterer,
-           '-i', args.decomposed_data,
+           '-i', args.decomp_data,
            '--out', args.clusterer_out,
            '--transformed', args.clustered_data,
-           '--n_clusters', str(args.n_clusters)].extend(args.clusterer_args.split(','))
+           '--n_clusters', str(args.n_clusters)]
+
+    if args.clusterer_args is not None:
+        cmd.extend(args.clusterer_args.split(','))
+
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'cluster.out'), 'w')
+        err = open(os.path.join('logs', 'cluster.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: Clustering failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
 
 
-def build_msm():
+def build_msm(args):
     """
 
     """
     cmd = ['msmb', args.msm,
            '-i', args.clustered_data,
            '--out', args.msm_out,
-           '--lag_time', str(args.lag_time)].extend(args.decomposer_args.split(','))
+           '--lag_time', str(args.lag_time)]
+
+    if args.msm_args is not None:
+        cmd.extend(args.msm_args.split(','))
+
     try:
-        subprocess.run('msmb MarkovStateModel -i labeled-trajs.h5 --out msm.pkl --lag_time 1',
-                       stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+        if not os.path.isdir('logs'):
+            os.mkdir('logs')
+        out = open(os.path.join('logs', 'msm.out'), 'w')
+        err = open(os.path.join('logs', 'msm.err'), 'w')
+        p = subprocess.Popen(cmd, stdout=out, stderr=err)
+        p.wait()
+        out.close()
+        err.close()
     except subprocess.CalledProcessError as e:
         print("Error: MSM Building failed")
         print("Caused by %s\n\n%s\n\n%s" % (e.cmd, e.stdout, e.stderr))
 
 
-def save_samples(msm, clustering, xyz, n_samples, samples_dir):
+def save_samples(msm, labels, xyz, n_samples, samples_dir):
     """
     Extract samples from each state in the MSM and save each as an individual PDB.
 
 
     """
-    samples = msm.draw_samples(clustering, n_samples)
-    frames = draw_samples.map_drawn_samples(samples, xyz)
 
-    if not os.path.isdir(samples_dir):
-        os.mkdir(samples_dir)
+    state_count = {val: 0 for key, val in msm.mapping_.items()}
 
-    for i in range(0, msm.n_states_):
-        for j in range(0, n_samples):
-            samples = ''.join(['State', str(i), '-', str(j), '.pdb'])
-            frames[i][j].save(os.path.join(samples_dir, sample))
+    for i in range(0, len(labels)):
+        for j in range(0, len(labels[i])):
+            try:
+                state = msm.mapping_[labels[i][j]]
+                if state_count[state] < n_samples:
+                    num = state_count[state]
+                    filename = ''.join(['State', str(state), '-', str(num), '.pdb'])
+                    xyz[i][j].save(os.path.join(samples_dir, filename))
+                    state_count[state] += 1
+            except KeyError:
+                continue
+
+    print("Creating duplicates for low-population states...")
+    for key, val in state_count.items():
+        if val == 0:
+            print("Warning: No samples found in state %s" % (key))
+        elif key < n_samples:
+            print("Creating duplicates for state %s" % (key))
+            filename = ''.join(['State', str(key), '-0.pdb'])
+            traj = mdtraj.load(os.path.join(samples_dir, filename))
+            while val < n_samples:
+                outname = ''.join(['State', str(key), '-', str(val), '.pdb'])
+                traj.save(os.path.join(samples_dir, outname))
+                val += 1
 
 
-def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
+def save_state_centers(msm, clustering, clusterer, decomp, xyz, centers_dir):
     """
 
     """
-    centers = clusterer.cluster_centers_
     dists = {}
     centermap = {}
+
+    if not os.path.isdir(centers_dir):
+        os.mkdir(centers_dir)
 
     for i in range(0, len(clustering)):
         for j in range(0, len(clustering[i])):
             try:
-                label = clusterer.labels_[i][j]
+                label = clustering[i][j]
                 center = msm.mapping_[label]
-                dist = np.linalg.norm(clustering[i][j] - centers[label])
+                dist = np.linalg.norm(decomp[i][j] - clusterer.cluster_centers_[label])
                 if center != -1 and dist < dists[center]:
                     dists[center] = dist
                     centermap[center] = (i, j)
@@ -348,7 +410,7 @@ def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
     if not os.path.isdir(centers_dir):
         os.mkdir(centers_dir)
 
-    for key, val in centermap.iteritems():
+    for key, val in centermap.items():
         fname = ''.join(['Center', str(key), '.pdb'])
         traj = xyz[val[0]].slice([val[1]])
         traj.save(os.path.join(centers_dir, fname))
@@ -401,23 +463,34 @@ def save_weights(msm, weights_out):
 if __name__ == "__main__":
     args = parse_args(None)
 
+    print("Featurizing...")
     featurize(args)
+    print("Generating decomposition...")
     decompose(args)
+    print("Clustering...")
     cluster(args)
+    print("Building MSM...")
     build_msm(args)
 
-    msm = load(args.msm)
+    msm = load(args.msm_out)
     clustering = dataset(args.clustered_data)
-    clusterer = load(args.clusterer)
-    xyz = dataset(args.input_trajectories, args.topology)
+    clusterer = load(args.clusterer_out)
+    xyz = dataset(args.input_trajectories, topology=args.topology)
 
+    print("Saving %s samples per cell..." % (args.n_samples))
     save_samples(msm, clustering, xyz, args.n_samples, args.samples_out)
-    save_state_centers(msm, clustering, clusterer, xyz, args.centers_out)
+    print("Saving state centers...")
+    ticas = dataset(args.decomp_data)
+    save_state_centers(msm, clustering, clusterer, ticas, xyz, args.centers_out)
+    print("Saving cell weights...")
     save_weights(msm, args.weights_datafile)
     del msm
     del clustering
     del clusterer
     del xyz
-    save_cell_assignments(args.centers_out, args.reference, args.threshold,
+    del ticas
+    print("Saving cell color assignments and cell definitions...")
+    save_cell_assignments(args.centers_out, args.reference, args.folded_threshold,
                           args.atom_selection, args.folded_assignments[0],
                           args.folded_assignments[1], args.cells_datafile)
+    print("Done!")

--- a/scripts/awe-generate-inputs
+++ b/scripts/awe-generate-inputs
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+"""
+Extract AWE inputs from an existing MSM and corresponding clustering.
+
+Author: Jeff Kinnison <jkinniso@nd.edu>
+"""
+
+import argparse
+import copy
+import glob
+import os
+import os.path
+import mdtraj
+from msmbuilder.dataset import dataset
+from msmbuilder.utils import load, draw_samples
+import numpy as np
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-n', '--n-samples',
+                        required=True,
+                        type=int,
+                        help='the number of samples to draw from each MSM state'
+                        )
+
+    parser.add_argument('-m', '--msm',
+                        default='msm.pkl',
+                        type=str,
+                        help='path to the serialized MSMBuilder msm object'
+                        )
+
+    parser.add_argument('-c', '--clustering',
+                        default='clustering/',
+                        type=str,
+                        help='path to the clustered data'
+                        )
+
+    parser.add_argument('-C', '--clusterer',
+                        default='clusterer.pkl',
+                        type=str,
+                        help='path to serialized clusterer fit to clustering'
+                        )
+
+    parser.add_argument('-i', '--input-trajectories',
+                        default='trajectories',
+                        type=str,
+                        help='path to the input trajectories'
+                        )
+
+    parser.add_argument('-t', '--topology',
+                        default='input.pdb',
+                        type=str,
+                        help='path to the trajectory topology file'
+                        )
+
+    parser.add_argument('-r', '--reference',
+                        default='folded.pdb',
+                        type=str,
+                        help='path to the reference trajectory'
+                        )
+
+    parser.add_argument('-a', '--atom-selection',
+                        default='backbone',
+                        type=str,
+                        help='MDTraj/VMD atom selection string'
+                        )
+
+    parser.add_argument('--samples-out',
+                        default='samples',
+                        type=str,
+                        help='path to the cell sampling output directory'
+                        )
+
+    parser.add_argument('--centers-out',
+                        default='centers',
+                        type=str,
+                        help='path to the cell centers output directory'
+                        )
+
+    parser.add_argument('--folded-assignments',
+                        default=['folded.dat', 'unfolded.dat']
+                        nargs=2,
+                        type=str,
+                        help='paths to the cell assignment output files'
+                        )
+
+    parser.add_argument('--folded-threshold',
+                        default=3.0,
+                        type=float,
+                        help='RMSD to folded state threshold (AA)'
+                        )
+
+    parser.add_argument('--cells-datafile',
+                        default='cells.dat',
+                        type=str,
+                        help='the cell data output file'
+                        )
+
+    parser.add_argument('--weights-datafile',
+                        default='weights.dat',
+                        type=str,
+                        help='the cell weights data output file',
+                        )
+
+    return parser.parse_args(args)
+
+
+def save_samples(msm, clustering, xyz, n_samples, samples_dir):
+    """
+
+    """
+    samples = msm.draw_samples(clustering, n_samples)
+    frames = draw_samples.map_drawn_samples(samples, xyz)
+
+    if not os.path.isdir(samples_dir):
+        os.mkdir(samples_dir)
+
+    for i in range(0, msm.n_states_):
+        for j in range(0, n_samples):
+            samples = ''.join(['State', str(i), '-', str(j), '.pdb'])
+            frames[i][j].save(os.path.join(samples_dir, sample))
+
+
+def save_state_centers(msm, clustering, clusterer, xyz, centers_dir):
+    """
+
+    """
+    centers = clusterer.cluster_centers_
+    dists = {}
+    centermap = {}
+
+    for i in range(0, len(clustering)):
+        for j in range(0, len(clustering[i])):
+            try:
+                label = clusterer.labels_[i][j]
+                center = msm.mapping_[label]
+                dist = np.linalg.norm(clustering[i][j] - centers[label])
+                if center != -1 and dist < dists[label]:
+                    dists[center] = dist
+                    centermap[center] = (i, j)
+            except KeyError:
+                continue
+
+    if not os.path.isdir(centers_dir):
+        os.mkdir(centers_dir)
+
+    for key, val in centermap.iteritems():
+        fname = ''.join(['Center', str(key), '.pdb'])
+        traj = xyz[val[0]].slice([val[1]])
+        traj.save(os.path.join(centers_dir, fname))
+
+
+def save_cell_assignments(centers_dir, reference, threshold, atom_selection,
+                          folded_out, unfolded_out, cells_out):
+    """
+
+    """
+    ref = mdtraj.load(reference)
+
+    n_cells = len(glob.glob(os.path.join(centers_dir, '*.pdb')))
+
+    folded = open(folded_out, 'w')
+    unfolded = open(unfolded_out, 'w')
+    cells = open(cells_out, 'w')
+
+    cells.write(''.join(['ncells: ', str(n_cells),
+                         '\nncoords: ', str(ref.n_atoms),
+                         '\nndims: ', str(3), '\n\n']))
+
+    for i in range(0, n_cells):
+        fname = ''.join('Center', str(i), '.pdb')
+        traj = mdtraj.load(os.path.join(centers_dir, fname))
+        rmsd = mdtraj.rmsd(traj, ref,
+                           atom_indices=traj.topology.select(atom_selection))
+        if rmsd[0] < threshold:
+            folded.write(''.join([str(i), '\n']))
+        else:
+            unfolded.write(''.join([str(j), '\n']))
+
+        for atom in traj.xyz[0]:
+            cells.write(''.join([str(atom[0]), '\n',
+                                 str(atom[1]), '\n',
+                                 str(atom[2]), '\n']))
+
+        folded.close()
+        unfolded.close()
+        cells.close()
+
+
+def save_weights(msm, weights_out):
+    """
+
+    """
+    np.savetxt(weights_out, msm.populations_)
+
+
+if __name__ == "__main__":
+    args = parse_args(None)
+
+    msm = load(args.msm)
+    clustering = dataset(args.clustering)
+    clusterer = load(args.clusterer)
+    xyz = dataset(args.input_trajectories, args.topology)
+
+    save_samples(msm, clustering, xyz, args.n_samples, args.samples_out)
+    save_state_centers(msm, clustering, clusterer, xyz, args.centers_out)
+    save_weights(msm, args.weights_datafile)
+    del msm
+    del clustering
+    del clusterer
+    del xyz
+    save_cell_assignments(args.centers_out, args.reference, args.threshold,
+                          args.atom_selection, args.folded_assignments[0],
+                          args.folded_assignments[1], args.cells_datafile)


### PR DESCRIPTION
A script has been added to automatically generate AWE inputs using MSMBuilder 3.x. This script uses the `msmb` CLI to perform featurization, decomposition, clustering, and MSM construction. To run the script, use `awe-generate-inputs [opts] -n <n_samples_per_state>`.

Features:
- Any part of the default calls to `msmb` can be overridden by command-line option. If you want to featurize by RMSD instead of dihedral angles or cluster using spectral clustering instead of MiniBatchKMeans, all you have to do is pass in an argument
- Samples and cluster centers are drawn from real trajectory frames containing all of the molecular data for the frame. The previous clustering scheme would often interpolate hydrogens incorrectly, leading to bad models.
- All AWE inputs are written automatically using the default names and formats understood by AWE, with minimal user interaction
